### PR TITLE
Update 2017-01-08-cassandra-authentication-in-docker-container.md

### DIFF
--- a/_posts/2017-01-08-cassandra-authentication-in-docker-container.md
+++ b/_posts/2017-01-08-cassandra-authentication-in-docker-container.md
@@ -14,7 +14,7 @@ To enable authentication, just add this line to your `Dockerfile`:
 
 ~~~
 # Require user & pass for accessing Cassandra instance within container
-RUN echo "authenticator: PasswordAuthenticator" >> /etc/cassandra/cassandra.yaml
+RUN sed -i 's/authenticator: AllowAllAuthenticator/authenticator: PasswordAuthenticator/g' /etc/cassandra/cassandra.yaml
 ~~~
 
 All this does is add a line to the [cassandra.yaml](https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html)


### PR DESCRIPTION
The previous command works when you connect from the internally (inside the container) but fails if you try from the outside - because the previous config was not removed!

BTW, thanks for your contribution. I realised the problem after reading: https://github.com/spring-projects/spring-boot/issues/21487